### PR TITLE
Update program for future courses

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Built slides have [an index](https://galaxyproject.github.io/dagobah-training/20
 
 [Galaxy Training material](http://galaxyproject.github.io/training-material/)
 
-[Information and questions (Google Doc)](https://docs.google.com/document/d/1eo12xrdNIrFD1_SLDMQKXteysOGkR2c8l-sR_hl6sok/edit?usp=sharing)
+[Questions, topic nominations, lightning talk self-nominations, other info (Google Doc)](https://docs.google.com/document/d/1eo12xrdNIrFD1_SLDMQKXteysOGkR2c8l-sR_hl6sok/edit?usp=sharing)
 
 [**IMPORTANT! Workshop Evaluation form (please help us to be better)**](https://skjema.uio.no/galaxy-admin-workshop-2018-eva)
 
@@ -41,16 +41,15 @@ Timetable with sessions and material will be continously updated towards the wor
 | -------- | --------- | --------- | ----------- |
 | 08:30 | Registration |  |  |
 | 09:15 | Welcome and introduction | [Slides](https://galaxyproject.github.io/dagobah-training/2018-oslo/00-intro/intro.html) | All |
-| 09:30 | Deployment and platform options | [Slides](http://galaxyproject.github.io/training-material/topics/admin/tutorials/deployment-platforms-options/slides.html) | (B) |
-| 10:00 | Get a basic Galaxy server up and running | [Slides](https://galaxyproject.github.io/dagobah-training/2018-oslo/02-basic-server/get-galaxy.html) | (A) |
+| 09:45 | Deployment and platform options | [Slides](http://galaxyproject.github.io/training-material/topics/admin/tutorials/deployment-platforms-options/slides.html) | (B) |
 | 10:45 | **Morning break** | | |
-| 11:00 | Galaxy server optional necessities: PostgreSQL and nginx | [First Steps Slides](https://galaxyproject.github.io/dagobah-training/2018-oslo/03-production-basics/production.html), [First Steps Exercise](sessions/03-production-basics/ex1-first-steps.md), [PostgreSQL Slides](https://galaxyproject.github.io/dagobah-training/2018-oslo/03-production-basics/databases.html), [PostgreSQL Exercise](sessions/03-production-basics/ex2-postgres.md),  [nginx/Apache Slides](https://galaxyproject.github.io/dagobah-training/2018-oslo/03-production-basics/webservers.html), [nginx Exercise](sessions/03-production-basics/ex3-nginx.md), [Apache Exercise](sessions/03-production-basics/ex4-apache.md) (for reference)| (N) |
-| 12:15 | **Lunch** | | |
-| 13:00 | Galaxy server optional necessities (continued)| | |
-| 13:45 | Introduction to the Galaxy Tool Shed: Identifying and installing well-defined tools | [Slides (Shed)](https://galaxyproject.github.io/dagobah-training/2018-oslo/04-tool-shed/shed_intro.html), [Slides (Tools)](https://galaxyproject.github.io/dagobah-training/2018-oslo/04-tool-shed/tool_installation.html), [Slides (Dependencies)](https://galaxyproject.github.io/dagobah-training/2018-oslo/04-tool-shed/tool-dependencies.html)| (M) |
-| 15:00 | **Afternoon break** | | |
-| 15:15 | Defining and importing genomes, Data Managers | [Slides](https://galaxyproject.github.io/dagobah-training/2018-oslo/05-reference-genomes/reference_genomes.html), [Exercise](sessions/05-reference-genomes/ex1-reference-genomes.md) | (E) |
-| 16:50 | Extending your installation: FTP, SMTP, and more | [Slides](https://galaxyproject.github.io/dagobah-training/2018-oslo/06-extending-installation/extending.html), [Exercise](sessions/06-extending-installation/ex1-proftpd.md) | (A) |
+| 11:00 | Get a basic Galaxy server up and running | [Slides](https://galaxyproject.github.io/dagobah-training/2018-oslo/02-basic-server/get-galaxy.html) | (A) |
+| 12:00 | Galaxy server optional necessities: PostgreSQL and nginx | [First Steps Slides](https://galaxyproject.github.io/dagobah-training/2018-oslo/03-production-basics/production.html), [First Steps Exercise](sessions/03-production-basics/ex1-first-steps.md), [PostgreSQL Slides](https://galaxyproject.github.io/dagobah-training/2018-oslo/03-production-basics/databases.html), [PostgreSQL Exercise](sessions/03-production-basics/ex2-postgres.md),  [nginx/Apache Slides](https://galaxyproject.github.io/dagobah-training/2018-oslo/03-production-basics/webservers.html), [nginx Exercise](sessions/03-production-basics/ex3-nginx.md), [Apache Exercise](sessions/03-production-basics/ex4-apache.md) (for reference)| (N) |
+| 12:30 | **Lunch** | | |
+| 13:15 | Galaxy server optional necessities: PostgreSQL and nginx (continued) | | (N) |
+| 15:15 | **Afternoon break** | | |
+| 15:30 | Defining and importing genomes, Data Managers | [Slides](https://galaxyproject.github.io/dagobah-training/2018-oslo/05-reference-genomes/reference_genomes.html), [Exercise](sessions/05-reference-genomes/ex1-reference-genomes.md) | (E) |
+| 17:00 | Extending your installation: FTP, SMTP, and more | [Slides](https://galaxyproject.github.io/dagobah-training/2018-oslo/06-extending-installation/extending.html), [Exercise](sessions/06-extending-installation/ex1-proftpd.md) | (A) |
 | 18:00 | Close Day 1 | | All |
 
 
@@ -62,14 +61,14 @@ Timetable with sessions and material will be continously updated towards the wor
 | 09:00 | Welcome and questions |  | All |
 | 09:15 | Users, Groups, and Quotas | [Slides](http://galaxyproject.github.io/training-material/topics/admin/tutorials/users-groups-quotas/slides.html) | (B) |
 | 10:45 | **Morning break** | | |
-| 11:00 | Updating tools and supporting multiple versions of tools | [Exercise](sessions/04-tool-shed/ex-tool-management.md) | (M) |
+| 11:00 | Introduction to the Galaxy Tool Shed: Identifying and installing well-defined tools | [Slides (Shed)](https://galaxyproject.github.io/dagobah-training/2018-oslo/04-tool-shed/shed_intro.html), [Slides (Tools)](https://galaxyproject.github.io/dagobah-training/2018-oslo/04-tool-shed/tool_installation.html), [Slides (Dependencies)](https://galaxyproject.github.io/dagobah-training/2018-oslo/04-tool-shed/tool-dependencies.html)| (M) |
 | 12:30 | **Lunch** | | |
-| 13:15 | Improving the web serving experience with uWSGI | [Slides](https://galaxyproject.github.io/dagobah-training/2018-oslo/10-uwsgi/uwsgi.html), [Exercise](sessions/10-uwsgi/ex1-uwsgi.md) | (B) |
-| 14:15 | Controlling Galaxy with systemd and supervisor | [Slides](https://galaxyproject.github.io/dagobah-training/2018-oslo/11-systemd-supervisor/systemd-supervisor.html), [Exercise](sessions/11-systemd-supervisor/ex1-supervisor.md) | (E) |
-| 15:15 | **Afternoon break** | | |
-| 15:30 | Server monitoring and maintenance: Admin UI, Log files, Direct database queries, command line & scripts, what to backup and how | [Slides](http://galaxyproject.github.io/training-material/topics/admin/tutorials/monitoring-maintenance/slides.html), [Exercise](http://galaxyproject.github.io/training-material/topics/admin/tutorials/monitoring-maintenance/tutorial.html) | (B) |
-| 16:30 | Using and configuring external authentication services | [Slides](https://galaxyproject.github.io/dagobah-training/2018-oslo/13-external-auth/external-auth.html), [PAM Auth Exercise](sessions/13-external-auth/ex1-pam-auth.md), [Upstream Auth Exercise](sessions/13-external-auth/ex2-upstream-auth.md) | (N) |
-| 17:45 | Close Day 2 | | All |
+| 13:15 | Updating tools and supporting multiple versions of tools | [Exercise](sessions/04-tool-shed/ex-tool-management.md) | (M) |
+| 14:30 | Improving the web serving experience with uWSGI | [Slides](https://galaxyproject.github.io/dagobah-training/2018-oslo/10-uwsgi/uwsgi.html), [Exercise](sessions/10-uwsgi/ex1-uwsgi.md) | (B) |
+| 15:30 | **Afternoon break** | | |
+| 15:45 | Controlling Galaxy with systemd and supervisor | [Slides](https://galaxyproject.github.io/dagobah-training/2018-oslo/11-systemd-supervisor/systemd-supervisor.html), [Exercise](sessions/11-systemd-supervisor/ex1-supervisor.md) | (E) |
+| 16:45 | Using and configuring external authentication services | [Slides](https://galaxyproject.github.io/dagobah-training/2018-oslo/13-external-auth/external-auth.html), [PAM Auth Exercise](sessions/13-external-auth/ex1-pam-auth.md), [Upstream Auth Exercise](sessions/13-external-auth/ex2-upstream-auth.md) | (N) |
+| 18:00 | Close Day 2 | | All |
 
 **Free common dinner at 7pm at [Elias mat og sånt](http://www.cafeelias.no/nb/) located downtown.**
 
@@ -80,17 +79,16 @@ Timetable with sessions and material will be continously updated towards the wor
 | **Time** | **Topic** | **Links** | **Instructor** |
 | -------- | --------- | --------- | ----------- |
 | 09:00 | Welcome and questions |  | All |
-| 09:15 | Configuration management choices: Introduction to Ansible | [Slides](https://galaxyproject.github.io/dagobah-training/2018-oslo/14-ansible/ansible-introduction.html) | (E) |
-| 10:00 | Using Ansible to deploy Galaxy I | [Exercise 1](sessions/14-ansible/ex1-intro-ansible.md) | (E) |
+| 09:15 | Exploring the Galaxy job configuration file | [Slides](https://galaxyproject.github.io/dagobah-training/2018-oslo/15-job-conf/job_conf.html) | (N) |
+| 09:50 | Connecting Galaxy to a compute cluster | [Slides](http://galaxyproject.github.io/training-material/topics/admin/tutorials/connect-to-compute-cluster/slides.html), [Exercise](http://galaxyproject.github.io/training-material/topics/admin/tutorials/connect-to-compute-cluster/tutorial.html) | (B) |
 | 10:45 | **Morning break** | | |
-| 11:00 | Using Ansible to deploy Galaxy II | [Exercise 2](sessions/14-ansible/ex2-galaxy-ansible.md) | (E) |
+| 11:00 | Connecting Galaxy to a compute cluster (continued) |  | (B) |
 | 12:30 | **Lunch** | | |
-| 13:15 | Exploring the Galaxy job configuration file | [Slides](https://galaxyproject.github.io/dagobah-training/2018-oslo/15-job-conf/job_conf.html) | (N) |
-| 13:50 | Connecting Galaxy to a compute cluster I | [Slides](http://galaxyproject.github.io/training-material/topics/admin/tutorials/connect-to-compute-cluster/slides.html), [Exercise](http://galaxyproject.github.io/training-material/topics/admin/tutorials/connect-to-compute-cluster/tutorial.html) | (B) |
+| 13:15 | Configuration management choices: Introduction to Ansible | [Slides](https://galaxyproject.github.io/dagobah-training/2018-oslo/14-ansible/ansible-introduction.html) | (E) |
+| 14:00 | Using Ansible to deploy Galaxy | [Exercise 1](sessions/14-ansible/ex1-intro-ansible.md), [Exercise 2](sessions/14-ansible/ex2-galaxy-ansible.md) | (E) |
 | 15:30 | **Afternoon break** | | |
-| 15:45 | Connecting Galaxy to a compute cluster II |  | (B) |
-| 16:30 | Using heterogeneous compute resources | [Slides](https://galaxyproject.github.io/dagobah-training/2018-oslo/17-heterogenous/heterogeneous.html), [Exercise](sessions/17-heterogenous/ex1-pulsar.md) | (M) |
-| 17:30 | Using public and private cloud compute resources | [Slides](https://galaxyproject.github.io/dagobah-training/2018-oslo/18-clouds/clouds.html) | (E) |
+| 15:45 | Using Ansible to deploy Galaxy (continued) | | (E) |
+| 16:45 | Using heterogeneous compute resources | [Slides](https://galaxyproject.github.io/dagobah-training/2018-oslo/17-heterogenous/heterogeneous.html), [Exercise](sessions/17-heterogenous/ex1-pulsar.md) | (M) |
 | 18:00 | Close day 3 | | All |
 
 
@@ -106,8 +104,8 @@ Timetable with sessions and material will be continously updated towards the wor
 | 12:30 | **Lunch** | | |
 | 13:15 | Running Jupyter in Galaxy with Galaxy Interactive Environments | [Exercise](sessions/21-gie/ex1-jupyter.md) | (B) |
 | 15:30 | **Afternoon break** | | |
-| 15.45 | Uwsgi + mules | | (?) |
-| 16:45 | OPEN: Lightning talks | | |
+| 15:45 | Using public and private cloud compute resources | [Slides](https://galaxyproject.github.io/dagobah-training/2018-oslo/18-clouds/clouds.html) | (E) |
+| 16:30 | Server monitoring and maintenance: Admin UI, Log files, Direct database queries, command line & scripts, what to backup and how | [Slides](http://galaxyproject.github.io/training-material/topics/admin/tutorials/monitoring-maintenance/slides.html), [Exercise 1](http://galaxyproject.github.io/training-material/topics/admin/tutorials/monitoring-maintenance/tutorial.html), [Exercise 2](sessions/22-troubleshooting/ex1-sentry.md) | (B,M) |
 | 18:00 | Wrap up and close | | All |
 
 
@@ -117,11 +115,11 @@ Timetable with sessions and material will be continously updated towards the wor
 | **Time** | **Topic** | **Links** | **Instructor** |
 | -------- | --------- | --------- | ----------- |
 | 09:00 | Welcome and questions |  | All |
-| 09.15 | Lightning talks (continued) | | (?) |
+| 09.15 | OPEN: Lightning talks | | Trainees |
 | 10:15 | Upgrading to a new Galaxy release | [Slides](https://galaxyproject.github.io/dagobah-training/2018-oslo/08-upgrading-release/upgrading.html) | (N) |
-| 11:00 | **Morning break** | | |
-| 11:15 | Server monitoring and maintenance: Admin UI, Log files, Direct database queries, command line & scripts, what to backup and how | [Slides](http://galaxyproject.github.io/training-material/topics/admin/tutorials/monitoring-maintenance/slides.html), [Exercise 1](http://galaxyproject.github.io/training-material/topics/admin/tutorials/monitoring-maintenance/tutorial.html), [Exercise 2](sessions/22-troubleshooting/ex1-sentry.md) | (B,M) |
+| 10:45 | **Morning break** | | |
+| 11.00 | What's new in Galaxy 18.01? | [Slides](https://galaxyproject.github.io/dagobah-training/2018-oslo/whatsnew/18.01.html) | (N) |
 | 12:30 | **Lunch** | | |
-| 13.15 | Whats new in Galaxy 18.01? | [Slides](https://galaxyproject.github.io/dagobah-training/2018-oslo/whatsnew/18.01.html) | (?) |
-| 14:15 | When things go wrong: Galaxy Server Troubleshooting | [Slides](https://galaxyproject.github.io/dagobah-training/2018-oslo/22-troubleshooting/troubleshooting.html) | (M) |
+| 13:15 | **Trainees' feedback survey** | [Form](https://skjema.uio.no/galaxy-admin-workshop-2018-eva) | Trainees |
+| 13:30 | When things go wrong: Galaxy Server Troubleshooting | [Slides](https://galaxyproject.github.io/dagobah-training/2018-oslo/22-troubleshooting/troubleshooting.html) | (M) |
 | 15:30 | Wrap up and close | | All |


### PR DESCRIPTION
- Move Ansible after "Connecting Galaxy to a compute cluster"
- Move "Introduction to the Galaxy Tool Shed: Identifying and installing well-defined tools" just before the "Updating tools and supporting multiple versions of tools" exercises
- Add "Trainees' feedback survey" (0:30)
- Move "Using public and private cloud compute resources" and "Server monitoring and maintenance" to Thursday
- Significant time changes:
  - Welcome and introduction 0:15 -> 0:30 (to allow for trainee self-introductions)
  - Deployment and platform options 0:30 -> 1:00 (lots of questions)
  - Get a basic Galaxy server up and running 0:45 -> 1:00 (to help with VM connection issues)
  - Galaxy server optional necessities: PostgreSQL and nginx 2:00 -> 2:30 (took longer)
  - Ansible sessions 3:15 -> 3:45
  - Using public and private cloud compute resources 0:30 -> 0:45 (took longer)
  - Server monitoring and maintenance 1:00 -> 1:30 (lots of new stuff)
  - Lightning talks 2:15 -> 1:00 (very few people interested)
  - When things go wrong: Galaxy Server Troubleshooting 2:15 -> 2:00